### PR TITLE
Remove 'superstitious' nonce manipulations

### DIFF
--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -12,7 +12,6 @@
     * [miner_getstat1](#miner_getstat1)
     * [miner_restart](#miner_restart)
     * [miner_reboot](#miner_reboot)
-    * [miner_shuffle](#miner_shuffle)
     * [miner_getconnections](#miner_getconnections)
     * [miner_setactiveconnection](#miner_setactiveconnection)
     * [miner_addconnection](#miner_addconnection)
@@ -92,7 +91,6 @@ This shows the API interface is live and listening on the configured endpoint.
 | [miner_getstat1](#miner_getstat1) | Request the retrieval of operational data in compatible format | No
 | [miner_restart](#miner_restart) | Instructs ethminer to stop and restart mining | Yes |
 | [miner_reboot](#miner_reboot) | Try to launch reboot.bat (on Windows) or reboot.sh (on Linux) in the ethminer executable directory | Yes
-| [miner_shuffle](#miner_shuffle) | Initializes a new random scramble nonce | Yes
 | [miner_getconnections](#miner_getconnections) | Returns the list of connections held by ethminer | No
 | [miner_setactiveconnection](#miner_setactiveconnection) | Instruct ethminer to immediately connect to the specified connection | Yes
 | [miner_addconnection](#miner_addconnection) | Provides ethminer with a new connection to use | Yes
@@ -351,40 +349,6 @@ and expect back a result like this:
 which confirms an executable file was found and ethminer tried to start it.
 
 **Note**: This method is not available if the API interface is in read-only mode (see above).
-
-### miner_shuffle
-
-The mining process is nothing more that finding the right number (nonce) which, applied to an algorithm (ethash) and some data, gives a result which is below or equal to a given target. This is very very (very) short!
-The range of nonces to be searched is a huge number: 2^64 = 18446744073709600000~ possible values. Each one has the same probability to be the _right_ one.
-
-Every time ethminer receives a job from a pool you'd expect the miner to begin searching from the first, but that would be boring. So the concept of scramble nonce has been introduced to achieve these goals:
-
-* Start the searching from a random point within the range
-* Ensure all GPUs do not search the same data, or, in other words, ensure each GPU searches its own range of numbers without overlapping with the same numbers of the other GPUs
-
-All `miner_shuffle` method does is to re-initialize a new random scramble nonce to start from in next jobs.
-
-To invoke the action:
-
-```js
-{
-  "id": 1,
-  "jsonrpc": "2.0",
-  "method": "miner_shuffle"
-}
-```
-
-and expect back a result like this:
-
-```js
-{
-  "id": 1,
-  "jsonrpc": "2.0",
-  "result": true
-}
-```
-
-which confirms the action has been performed.
 
 ### miner_getconnections
 

--- a/ethminer/main.cpp
+++ b/ethminer/main.cpp
@@ -242,8 +242,6 @@ public:
 
         app.add_set("-A,--algo", m_PoolSettings.algo, {"ethash", "progpow"}, "", true);
 
-        app.add_option("--ergodicity", m_FarmSettings.ergodicity, "", true)->check(CLI::Range(0, 2));
-
         app.add_option("--startnonce", m_FarmSettings.startNonce, "", true)
             ->check(CLI::Range(1ull, 18446744073709551615ull));
 
@@ -501,15 +499,6 @@ public:
                 std::string what = "-tstop must be greater than -tstart";
                 throw std::invalid_argument(what);
             }
-        }
-
-        if (m_FarmSettings.ergodicity != 0 && m_FarmSettings.startNonce)
-        {
-            // If we got a --startnonce and
-            // change nonce every job/session:
-            //      generate an error
-            std::string what = "You can not mix --ergodicity and --startnonce";
-            throw std::invalid_argument(what);
         }
 
         // Output warnings if any
@@ -1042,12 +1031,6 @@ public:
                  << "                        2 As 1 plus monitor power drain" << endl
                  << endl
                  << "    --exit              FLAG Stop ethminer whenever an error is encountered" << endl
-                 << "    --ergodicity        INT[0 .. 2] Default = 0" << endl
-                 << "                        Sets how ethminer chooses the nonces segments to" << endl
-                 << "                        search on." << endl
-                 << "                        0 A search segment is picked at startup" << endl
-                 << "                        1 A search segment is picked on every pool connection" << endl
-                 << "                        2 A search segment is picked on every new job" << endl
                  << "    --startnonce        UINT[1 .. 184467440737095516162] Default: not set" << endl
                  << "                        Set the nonce to an explicit value." << endl
                  << "                        This is only useful if you benchmark!" << endl

--- a/libapicore/ApiServer.cpp
+++ b/libapicore/ApiServer.cpp
@@ -432,15 +432,6 @@ void ApiConnection::processRequest(Json::Value& jRequest, Json::Value& jResponse
         jResponse["result"] = getMinerStatDetail();
     }
 
-    else if (_method == "miner_shuffle")
-    {
-        if (!checkApiWriteAccess(m_readonly, jResponse))
-            return;
-        // Gives nonce scrambler a new range
-        jResponse["result"] = true;
-        Farm::f().shuffle();
-    }
-
     else if (_method == "miner_ping")
     {
         // Replies back to (check for liveness)

--- a/libethcore/Farm.h
+++ b/libethcore/Farm.h
@@ -53,7 +53,6 @@ struct FarmSettings
     unsigned dagLoadMode = 0;         // 0 = Parallel; 1 = Serialized
     bool noEval = false;              // Whether or not to re-evaluate solutions
     unsigned hwMon = 0;               // 0 - No monitor; 1 - Temp and Fan; 2 - Temp Fan Power
-    unsigned ergodicity = 0;          // 0=default, 1=per session, 2=per job
     uint64_t startNonce = 0;          // 0=not set, each other value: use it as nonce
     unsigned nonceSegmentWidth = 32;  //
     unsigned tempStart = 40;          // Temperature threshold to restart mining (if paused)
@@ -76,11 +75,6 @@ public:
     ~Farm();
 
     static Farm& f() { return *m_this; }
-
-    /**
-     * @brief Randomizes the nonce scrambler
-     */
-    void shuffle();
 
     /**
      * @brief Sets the current mining mission.
@@ -235,8 +229,6 @@ public:
     unsigned get_tstart() override { return m_Settings.tempStart; }
 
     unsigned get_tstop() override { return m_Settings.tempStop; }
-
-    unsigned get_ergodicity() override { return m_Settings.ergodicity; }
 
     /**
      * @brief Called from a Miner to note a WorkPackage has a solution.

--- a/libethcore/Miner.h
+++ b/libethcore/Miner.h
@@ -344,7 +344,6 @@ public:
     virtual ~FarmFace() = default;
     virtual unsigned get_tstart() = 0;
     virtual unsigned get_tstop() = 0;
-    virtual unsigned get_ergodicity() = 0;
 
     /**
      * @brief Called from a Miner to note a WorkPackage has a solution.

--- a/libpoolprotocols/PoolManager.cpp
+++ b/libpoolprotocols/PoolManager.cpp
@@ -75,10 +75,6 @@ void PoolManager::setClientHandlers()
             m_currentWp.job.clear();
             m_currentWp.header = h256();
 
-            // Shuffle if needed
-            if (Farm::f().get_ergodicity() == 1U)
-                Farm::f().shuffle();
-
             // Rough implementation to return to primary pool
             // after specified amount of time
             if (m_activeConnectionIdx != 0 && m_Settings.poolFailoverTimeout)


### PR DESCRIPTION
All nonces are equally likely to be a solution, it is mathematically
unsound and superstitious to periodically alter the start nonce.

- Delete nonsense ergodicity parameter
- Get rid of nonce 'shuffle' API